### PR TITLE
feat: add docs for /me/blockers endpoint and block/unblock webhook events

### DIFF
--- a/bundled.json
+++ b/bundled.json
@@ -221015,6 +221015,390 @@
         }
       }
     },
+    "/api/v4/me/blockers": {
+      "get": {
+        "summary": "Get Blockers",
+        "description": "Get the list of users who have blocked the current user.\n",
+        "tags": [
+          "User"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 10
+            }
+          },
+          {
+            "name": "token",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Get blockers list response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "follows": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "from": {
+                            "type": "string"
+                          },
+                          "fromUserPublicId": {
+                            "type": "string"
+                          },
+                          "fromUserInternalId": {
+                            "type": "string"
+                          },
+                          "to": {
+                            "type": "string"
+                          },
+                          "toUserPublicId": {
+                            "type": "string"
+                          },
+                          "toUserInternalId": {
+                            "type": "string"
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "blocked",
+                              "pending",
+                              "accepted",
+                              "none"
+                            ]
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "updatedAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          }
+                        }
+                      }
+                    },
+                    "users": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "_id": {
+                            "type": "string",
+                            "description": "Private ID of a user. (for real-time event)"
+                          },
+                          "path": {
+                            "type": "string",
+                            "description": "Path of a user. (for real-time event)"
+                          },
+                          "userId": {
+                            "type": "string"
+                          },
+                          "userInternalId": {
+                            "type": "string"
+                          },
+                          "userPublicId": {
+                            "type": "string"
+                          },
+                          "roles": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "permissions": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "enum": [
+                                "MUTE_CHANNEL",
+                                "CLOSE_CHANNEL",
+                                "EDIT_CHANNEL",
+                                "EDIT_CHANNEL_RATELIMIT",
+                                "EDIT_MESSAGE",
+                                "DELETE_MESSAGE",
+                                "BAN_USER_FROM_CHANNEL",
+                                "MUTE_USER_INSIDE_CHANNEL",
+                                "ADD_CHANNEL_USER",
+                                "REMOVE_CHANNEL_USER",
+                                "EDIT_CHANNEL_USER",
+                                "ASSIGN_CHANNEL_USER_ROLE",
+                                "BAN_USER",
+                                "EDIT_USER",
+                                "ASSIGN_USER_ROLE",
+                                "EDIT_USER_FEED_POST",
+                                "DELETE_USER_FEED_POST",
+                                "EDIT_USER_FEED_COMMENT",
+                                "DELETE_USER_FEED_COMMENT",
+                                "ADD_COMMUNITY_USER",
+                                "REMOVE_COMMUNITY_USER",
+                                "EDIT_COMMUNITY_USER",
+                                "BAN_COMMUNITY_USER",
+                                "MUTE_COMMUNITY_USER",
+                                "EDIT_COMMUNITY",
+                                "DELETE_COMMUNITY",
+                                "EDIT_COMMUNITY_POST",
+                                "DELETE_COMMUNITY_POST",
+                                "PIN_COMMUNITY_POST",
+                                "EDIT_COMMUNITY_COMMENT",
+                                "DELETE_COMMUNITY_COMMENT",
+                                "ASSIGN_COMMUNITY_USER_ROLE",
+                                "CREATE_COMMUNITY_CATEGORY",
+                                "EDIT_COMMUNITY_CATEGORY",
+                                "DELETE_COMMUNITY_CATEGORY",
+                                "CREATE_ROLE",
+                                "EDIT_ROLE",
+                                "DELETE_ROLE",
+                                "MANAGE_COMMUNITY_STORY"
+                              ]
+                            }
+                          },
+                          "displayName": {
+                            "type": "string"
+                          },
+                          "profileHandle": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "avatarFileId": {
+                            "type": "string"
+                          },
+                          "avatarCustomUrl": {
+                            "type": "string"
+                          },
+                          "flagCount": {
+                            "type": "integer"
+                          },
+                          "hashFlag": {
+                            "type": "object",
+                            "properties": {
+                              "bits": {
+                                "type": "integer"
+                              },
+                              "hashes": {
+                                "type": "integer"
+                              },
+                              "hash": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "metadata": {
+                            "type": "object"
+                          },
+                          "isGlobalBan": {
+                            "type": "boolean",
+                            "description": "Global ban status. Every user can see this flag."
+                          },
+                          "isBrand": {
+                            "type": "boolean",
+                            "description": "Brand user status."
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "updatedAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "isDeleted": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "userId",
+                          "createdAt",
+                          "updatedAt"
+                        ]
+                      }
+                    },
+                    "files": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "fileId": {
+                            "type": "string",
+                            "description": "Root file key on cloud storage."
+                          },
+                          "fileUrl": {
+                            "type": "string",
+                            "description": "Http link for download file"
+                          },
+                          "type": {
+                            "type": "string",
+                            "description": "File type.",
+                            "enum": [
+                              "image",
+                              "file",
+                              "video"
+                            ]
+                          },
+                          "accessType": {
+                            "type": "string",
+                            "description": "File access type. `network` type requires authentication to download.",
+                            "enum": [
+                              "public",
+                              "network"
+                            ],
+                            "default": "public"
+                          },
+                          "altText": {
+                            "type": "string",
+                            "description": "Alternative text for the file.",
+                            "maxLength": 180
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "description": "The date/time when a file is uploaded.",
+                            "format": "date-time"
+                          },
+                          "updatedAt": {
+                            "type": "string",
+                            "description": "The date/time when a file is updated.",
+                            "format": "date-time"
+                          },
+                          "attributes": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string",
+                                "description": "File name."
+                              },
+                              "extension": {
+                                "type": "string",
+                                "description": "File format."
+                              },
+                              "size": {
+                                "type": "number",
+                                "description": "File size."
+                              },
+                              "mimeType": {
+                                "type": "string",
+                                "description": "File mime-type."
+                              },
+                              "metadata": {
+                                "type": "object",
+                                "description": "File image metadata (width, height etc.).",
+                                "properties": {
+                                  "exif": {
+                                    "type": "object"
+                                  },
+                                  "gps": {
+                                    "type": "object"
+                                  },
+                                  "height": {
+                                    "type": "number"
+                                  },
+                                  "width": {
+                                    "type": "number"
+                                  },
+                                  "isFull": {
+                                    "type": "boolean"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "paging": {
+                      "type": "object",
+                      "properties": {
+                        "next": {
+                          "type": "string",
+                          "description": "token for getting the next page of data",
+                          "maxLength": 100
+                        },
+                        "previous": {
+                          "type": "string",
+                          "description": "token for getting the previous page of data",
+                          "maxLength": 100
+                        },
+                        "total": {
+                          "type": "number",
+                          "description": "total number of blockers"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "number"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "detail": {
+                          "oneOf": [
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            {
+                              "type": "object"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "status": "error",
+                  "code": 500000,
+                  "message": "Unexpected error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v2/users/ban": {
       "post": {
         "summary": "Ban a User",

--- a/bundled.json
+++ b/bundled.json
@@ -255311,6 +255311,62 @@
         }
       }
     },
+    "/webhook/user.didBlock": {
+      "get": {
+        "tags": [
+          "Webhook event"
+        ],
+        "summary": "User Didblock webhook event",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "description": "This is called when a user blocks another user.\n",
+        "responses": {
+          "200": {
+            "description": "Block event information. data contains the follow relationship (from, to, status), users is a list of userInfo, files is a list of file information",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "event": {
+                      "type": "string"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "from": {
+                          "type": "string"
+                        },
+                        "to": {
+                          "type": "string"
+                        },
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "none"
+                          ]
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/webhook/user.didClearFlag": {
       "get": {
         "tags": [
@@ -256101,6 +256157,62 @@
                               }
                             }
                           }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/webhook/user.didUnblock": {
+      "get": {
+        "tags": [
+          "Webhook event"
+        ],
+        "summary": "User Didunblock webhook event",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "description": "This is called when a user unblocks another user.\n",
+        "responses": {
+          "200": {
+            "description": "Unblock event information. data contains the follow relationship (from, to, status), users is a list of userInfo, files is a list of file information",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "event": {
+                      "type": "string"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "from": {
+                          "type": "string"
+                        },
+                        "to": {
+                          "type": "string"
+                        },
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "none"
+                          ]
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                          "format": "date-time"
                         }
                       }
                     }

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -637,12 +637,16 @@ paths:
     $ref: "./webhook/push-notification/index.yaml#/mention-user-feed-comment.replied"
   /webhook/push-notification/mention-user-feed-post.created:
     $ref: "./webhook/push-notification/index.yaml#/mention-user-feed-post.created"
+  /webhook/user.didBlock:
+    $ref: "./webhook/user/index.yaml#/user.didBlock"
   /webhook/user.didClearFlag:
     $ref: "./webhook/user/index.yaml#/user.didClearFlag"
   /webhook/user.didCreate:
     $ref: "./webhook/user/index.yaml#/user.didCreate"
   /webhook/user.didFlag:
     $ref: "./webhook/user/index.yaml#/user.didFlag"
+  /webhook/user.didUnblock:
+    $ref: "./webhook/user/index.yaml#/user.didUnblock"
   /webhook/user.didUnflag:
     $ref: "./webhook/user/index.yaml#/user.didUnflag"
   /webhook/user.didUpdate:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -511,6 +511,8 @@ paths:
     $ref: "./v3/user/index.yaml#/_userId-isFlagByMe"
   /api/v4/me/user-blocks:
     $ref: "./v4/user/index.yaml#/me-user-blocks"
+  /api/v4/me/blockers:
+    $ref: "./v4/user/index.yaml#/me-blockers"
   /api/v2/users/ban:
     $ref: "./v2/user/index.yaml#/ban"
   /api/v2/users/unban:

--- a/v4/user/index.yaml
+++ b/v4/user/index.yaml
@@ -72,6 +72,23 @@ me-user-blocks:
       500:
         $ref: "../../global/error.yaml#/UnexpectedError"
 
+me-blockers:
+  get:
+    summary: Get Blockers
+    description: "Get the list of users who have blocked the current user.\n"
+    tags:
+      - User
+    security:
+      - BearerAuth: []
+    parameters:
+      - $ref: "./parameter.yaml#/limit"
+      - $ref: "./parameter.yaml#/token"
+    responses:
+      200:
+        $ref: "./response.yaml#/me-blockers-get-response-200"
+      500:
+        $ref: "../../global/error.yaml#/UnexpectedError"
+
 me-user-blocks_userId:
   post:
     summary: Block a User

--- a/v4/user/response.yaml
+++ b/v4/user/response.yaml
@@ -112,3 +112,37 @@ me-user-blocks-get-response-200:
               total:
                 type: number
                 description: total number of blockers
+
+me-blockers-get-response-200:
+  description: Get blockers list response
+  content:
+    application/json:
+      schema:
+        type: object
+        properties:
+          follows:
+            type: array
+            items:
+              $ref: "../../schema/follow.yaml#/FollowV5"
+          users:
+            type: array
+            items:
+              $ref: "../../schema/user.yaml#/UserV3"
+          files:
+            type: array
+            items:
+              $ref: "../../schema/file.yaml#/File"
+          paging:
+            type: object
+            properties:
+              next:
+                type: string
+                description: token for getting the next page of data
+                maxLength: 100
+              previous:
+                type: string
+                description: token for getting the previous page of data
+                maxLength: 100
+              total:
+                type: number
+                description: total number of blockers

--- a/webhook/user/index.yaml
+++ b/webhook/user/index.yaml
@@ -1,3 +1,15 @@
+user.didBlock:
+  get:
+    tags:
+      - "Webhook event"
+    summary: "User Didblock webhook event"
+    security:
+      - BearerAuth: []
+    description: "This is called when a user blocks another user.\n"
+    responses:
+      200:
+        description: "Block event information. data contains the follow relationship (from, to, status), users is a list of userInfo, files is a list of file information"
+        $ref: "../../v4/follow/response.yaml#/follow-webhook-response"
 user.didClearFlag:
   get:
     tags:
@@ -34,6 +46,18 @@ user.didFlag:
       200:
         description: "User flag event information. users is a list of userInfo. files is a list of file information"
         $ref: "../../v1/user/response.yaml#/user-webhook-response"
+user.didUnblock:
+  get:
+    tags:
+      - "Webhook event"
+    summary: "User Didunblock webhook event"
+    security:
+      - BearerAuth: []
+    description: "This is called when a user unblocks another user.\n"
+    responses:
+      200:
+        description: "Unblock event information. data contains the follow relationship (from, to, status), users is a list of userInfo, files is a list of file information"
+        $ref: "../../v4/follow/response.yaml#/follow-webhook-response"
 user.didUnflag:
   get:
     tags:


### PR DESCRIPTION
## Summary
Documents the block-relationship surface that was missing from the API reference:

1. **`GET /api/v4/me/blockers`** — returns the list of users who have blocked the current user (the reverse of the existing `/me/user-blocks`, which lists users *you* blocked).
2. **`user.didBlock`** / **`user.didUnblock`** webhook events — emitted when a user blocks/unblocks another user.

## Backend reference (`EkoMessagingService`)
- Route: `src/services/v1/api.service.js` → `'GET me/blockers': 'v4.follow.getBlockersList'`
- Handler: `src/services/v4/follow.service.ts` → `getBlockersList`
- Webhook events: `src/modules/social/follow/helpers/follow.helper.ts` emits `user.didBlock` / `user.didUnblock`; delivered in `src/services/v1/google-pub-sub.service.js`. Payload is follow-shaped (`from`, `to`, `status`, `follows`, `users`, `files`).

## Changes
- `v4/user/index.yaml` — new `me-blockers` path item (GET, BearerAuth, `limit`/`token` params)
- `v4/user/response.yaml` — new `me-blockers-get-response-200`
- `webhook/user/index.yaml` — new `user.didBlock` and `user.didUnblock` events (reuse `follow-webhook-response`)
- `swagger.yaml` — register `/api/v4/me/blockers`, `/webhook/user.didBlock`, `/webhook/user.didUnblock`
- `bundled.json` — regenerated via `npm run build`

## Verification
- `npm run build` succeeds; all three paths present in `bundled.json`
- The single remaining `npm run lint` error is pre-existing (`v1/event` missing `operationId`) and unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)