### PR TITLE
docs(webhook): document user.profileReset webhook event

### DIFF
--- a/bundled.json
+++ b/bundled.json
@@ -257253,6 +257253,273 @@
         }
       }
     },
+    "/webhook/user.profileReset": {
+      "get": {
+        "tags": [
+          "Webhook event"
+        ],
+        "summary": "User Profilereset webhook event",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "description": "This is called when a user's profile is reset by an admin (moderation).\n",
+        "responses": {
+          "200": {
+            "description": "User profile reset event information. users is a list of userInfo. files is a list of file information",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "event": {
+                      "type": "string"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "users": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "_id": {
+                                "type": "string",
+                                "description": "Private ID of a user. (for real-time event)"
+                              },
+                              "path": {
+                                "type": "string",
+                                "description": "Path of a user. (for real-time event)"
+                              },
+                              "userId": {
+                                "type": "string"
+                              },
+                              "userInternalId": {
+                                "type": "string"
+                              },
+                              "userPublicId": {
+                                "type": "string"
+                              },
+                              "roles": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "permissions": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string",
+                                  "enum": [
+                                    "MUTE_CHANNEL",
+                                    "CLOSE_CHANNEL",
+                                    "EDIT_CHANNEL",
+                                    "EDIT_CHANNEL_RATELIMIT",
+                                    "EDIT_MESSAGE",
+                                    "DELETE_MESSAGE",
+                                    "BAN_USER_FROM_CHANNEL",
+                                    "MUTE_USER_INSIDE_CHANNEL",
+                                    "ADD_CHANNEL_USER",
+                                    "REMOVE_CHANNEL_USER",
+                                    "EDIT_CHANNEL_USER",
+                                    "ASSIGN_CHANNEL_USER_ROLE",
+                                    "BAN_USER",
+                                    "EDIT_USER",
+                                    "ASSIGN_USER_ROLE",
+                                    "EDIT_USER_FEED_POST",
+                                    "DELETE_USER_FEED_POST",
+                                    "EDIT_USER_FEED_COMMENT",
+                                    "DELETE_USER_FEED_COMMENT",
+                                    "ADD_COMMUNITY_USER",
+                                    "REMOVE_COMMUNITY_USER",
+                                    "EDIT_COMMUNITY_USER",
+                                    "BAN_COMMUNITY_USER",
+                                    "MUTE_COMMUNITY_USER",
+                                    "EDIT_COMMUNITY",
+                                    "DELETE_COMMUNITY",
+                                    "EDIT_COMMUNITY_POST",
+                                    "DELETE_COMMUNITY_POST",
+                                    "PIN_COMMUNITY_POST",
+                                    "EDIT_COMMUNITY_COMMENT",
+                                    "DELETE_COMMUNITY_COMMENT",
+                                    "ASSIGN_COMMUNITY_USER_ROLE",
+                                    "CREATE_COMMUNITY_CATEGORY",
+                                    "EDIT_COMMUNITY_CATEGORY",
+                                    "DELETE_COMMUNITY_CATEGORY",
+                                    "CREATE_ROLE",
+                                    "EDIT_ROLE",
+                                    "DELETE_ROLE",
+                                    "MANAGE_COMMUNITY_STORY"
+                                  ]
+                                }
+                              },
+                              "displayName": {
+                                "type": "string"
+                              },
+                              "profileHandle": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "type": "string"
+                              },
+                              "avatarFileId": {
+                                "type": "string"
+                              },
+                              "avatarCustomUrl": {
+                                "type": "string"
+                              },
+                              "flagCount": {
+                                "type": "integer"
+                              },
+                              "hashFlag": {
+                                "type": "object",
+                                "properties": {
+                                  "bits": {
+                                    "type": "integer"
+                                  },
+                                  "hashes": {
+                                    "type": "integer"
+                                  },
+                                  "hash": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "type": "object"
+                              },
+                              "isGlobalBan": {
+                                "type": "boolean",
+                                "description": "Global ban status. Every user can see this flag."
+                              },
+                              "isBrand": {
+                                "type": "boolean",
+                                "description": "Brand user status."
+                              },
+                              "createdAt": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "updatedAt": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "isDeleted": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "userId",
+                              "createdAt",
+                              "updatedAt"
+                            ]
+                          }
+                        },
+                        "files": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "fileId": {
+                                "type": "string",
+                                "description": "Root file key on cloud storage."
+                              },
+                              "fileUrl": {
+                                "type": "string",
+                                "description": "Http link for download file"
+                              },
+                              "type": {
+                                "type": "string",
+                                "description": "File type.",
+                                "enum": [
+                                  "image",
+                                  "file",
+                                  "video"
+                                ]
+                              },
+                              "accessType": {
+                                "type": "string",
+                                "description": "File access type. `network` type requires authentication to download.",
+                                "enum": [
+                                  "public",
+                                  "network"
+                                ],
+                                "default": "public"
+                              },
+                              "altText": {
+                                "type": "string",
+                                "description": "Alternative text for the file.",
+                                "maxLength": 180
+                              },
+                              "createdAt": {
+                                "type": "string",
+                                "description": "The date/time when a file is uploaded.",
+                                "format": "date-time"
+                              },
+                              "updatedAt": {
+                                "type": "string",
+                                "description": "The date/time when a file is updated.",
+                                "format": "date-time"
+                              },
+                              "attributes": {
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "type": "string",
+                                    "description": "File name."
+                                  },
+                                  "extension": {
+                                    "type": "string",
+                                    "description": "File format."
+                                  },
+                                  "size": {
+                                    "type": "number",
+                                    "description": "File size."
+                                  },
+                                  "mimeType": {
+                                    "type": "string",
+                                    "description": "File mime-type."
+                                  },
+                                  "metadata": {
+                                    "type": "object",
+                                    "description": "File image metadata (width, height etc.).",
+                                    "properties": {
+                                      "exif": {
+                                        "type": "object"
+                                      },
+                                      "gps": {
+                                        "type": "object"
+                                      },
+                                      "height": {
+                                        "type": "number"
+                                      },
+                                      "width": {
+                                        "type": "number"
+                                      },
+                                      "isFull": {
+                                        "type": "boolean"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/webhook/v3.comment.didAddReaction": {
       "get": {
         "tags": [

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -653,6 +653,8 @@ paths:
     $ref: "./webhook/user/index.yaml#/user.didUnflag"
   /webhook/user.didUpdate:
     $ref: "./webhook/user/index.yaml#/user.didUpdate"
+  /webhook/user.profileReset:
+    $ref: "./webhook/user/index.yaml#/user.profileReset"
   /webhook/v3.comment.didAddReaction:
     $ref: "./webhook/comment-v3/index.yaml#/comment.didAddReaction"
   /webhook/v3.comment.didCreate:

--- a/webhook/user/index.yaml
+++ b/webhook/user/index.yaml
@@ -82,3 +82,15 @@ user.didUpdate:
       200:
         description: "User updated event information. users is a list of userInfo. files is a list of file information"
         $ref: "../../v1/user/response.yaml#/user-webhook-response"
+user.profileReset:
+  get:
+    tags:
+      - "Webhook event"
+    summary: "User Profilereset webhook event"
+    security:
+      - BearerAuth: []
+    description: "This is called when a user's profile is reset by an admin (moderation).\n"
+    responses:
+      200:
+        description: "User profile reset event information. users is a list of userInfo. files is a list of file information"
+        $ref: "../../v1/user/response.yaml#/user-webhook-response"


### PR DESCRIPTION
## What

Documents the `user.profileReset` webhook event.

- Adds the `user.profileReset` event definition to `webhook/user/index.yaml` (reuses the shared `user-webhook-response` schema — payload is `users[]` + `files[]`, same as the other `user.*` webhook events).
- Registers the `/webhook/user.profileReset` path in `swagger.yaml`.
- Regenerates `bundled.json`.

## Why

The event is fired when an admin resets a user's profile via moderation (core's v1 google-pub-sub service republishes the internal `user.profileReset` event to customer Pub/Sub). It was missing from the API docs.

## Verification

- `npm run lint` (redocly) → *"Your API description is valid. 🎉"*
- `npm run build` regenerates `bundled.json` cleanly; pre-commit `prepare-local` hook passes.

## Related

Part of a cross-repo change adding `user.profileReset` to the webhook catalogue (core `DEFAULT_WEBHOOK_EVENTS`, ops-panel, console-web).